### PR TITLE
add exception name in exception logger

### DIFF
--- a/octobot_commons/logging/logging_util.pxd
+++ b/octobot_commons/logging/logging_util.pxd
@@ -23,7 +23,7 @@ cdef class BotLogger:
     cpdef void info(self, str message)
     cpdef void warning(self, str message)
     cpdef void error(self, str message)
-    cpdef exception(self, object exception, bint publish_error_if_necessary=*, object error_message=*)
+    cpdef exception(self, object exception, bint publish_error_if_necessary=*, object error_message=*, bint include_exception_name=*)
     cpdef void critical(self, str message)
     cpdef void fatal(self, str message)
     cpdef void disable(self, bint disabled)

--- a/octobot_commons/logging/logging_util.py
+++ b/octobot_commons/logging/logging_util.py
@@ -173,19 +173,26 @@ class BotLogger:
         self._publish_log_if_necessary(message, logging.ERROR)
 
     def exception(
-        self, exception, publish_error_if_necessary=True, error_message=None
+        self,
+        exception,
+        publish_error_if_necessary=True,
+        error_message=None,
+        include_exception_name=True,
     ) -> None:
         """
         Called for an exception log
         :param exception: the log exception
         :param publish_error_if_necessary: if the error should be published
         :param error_message: the log message
+        :param include_exception_name: when True adds the __class__.__name__ of the exception at the end of the message
         """
         self.logger.exception(exception)
         if publish_error_if_necessary:
             message = error_message
             if message is None:
                 message = exception if str(exception) else exception.__class__.__name__
+            elif include_exception_name:
+                message = f"{message} ({exception.__class__.__name__})"
             self.error(message)
 
     def critical(self, message) -> None:


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/9078616/99069312-6725cd80-25ae-11eb-984b-207903b6217b.png)
after:
![image](https://user-images.githubusercontent.com/9078616/99069322-6bea8180-25ae-11eb-9881-192b7dc843b9.png)

(by default now also adds the exception class name to prevent error messages without info when exception has not been created with an initial message during raise)