### PR TITLE
[Version] 1.5.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  
+## [1.5.16] - 2021-04-01 
+### Added
+- aiohttp util : download_stream_file
+ 
 ## [1.5.15] - 2021-04-01 
 ### Added
 - is_machine_64bit and is_arm_machine to os_util

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoBot-Commons [1.5.15](https://github.com/Drakkar-Software/OctoBot-Commons/blob/master/CHANGELOG.md)
+# OctoBot-Commons [1.5.16](https://github.com/Drakkar-Software/OctoBot-Commons/blob/master/CHANGELOG.md)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/b31f3ab3511744a5a5ca6b9bb48e77bb)](https://app.codacy.com/gh/Drakkar-Software/OctoBot-Commons?utm_source=github.com&utm_medium=referral&utm_content=Drakkar-Software/OctoBot-Commons&utm_campaign=Badge_Grade_Dashboard)
 [![PyPI](https://img.shields.io/pypi/v/OctoBot-Commons.svg)](https://pypi.python.org/pypi/OctoBot-Commons/)
 [![Coverage Status](https://coveralls.io/repos/github/Drakkar-Software/OctoBot-Commons/badge.svg?branch=master)](https://coveralls.io/github/Drakkar-Software/OctoBot-Commons?branch=master)

--- a/octobot_commons/__init__.py
+++ b/octobot_commons/__init__.py
@@ -16,7 +16,7 @@
 #  License along with this library.
 
 PROJECT_NAME = "OctoBot-Commons"
-VERSION = "1.5.15"  # major.minor.revision
+VERSION = "1.5.16"  # major.minor.revision
 
 MARKET_SEPARATOR = "/"
 DICT_BULLET_TOKEN_STR = "\n "

--- a/octobot_commons/aiohttp_util.py
+++ b/octobot_commons/aiohttp_util.py
@@ -14,11 +14,14 @@
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library.
 
-async def download_stream_file(output_file,
-                               file_url,
-                               aiohttp_session,
-                               data_chunk_size=5*2**20,
-                               is_aiofiles_output_file=False):
+
+async def download_stream_file(
+    output_file,
+    file_url,
+    aiohttp_session,
+    data_chunk_size=5 * 2 ** 20,
+    is_aiofiles_output_file=False,
+):
     """
     Download a big file with an aiohttp session
     :param output_file: the output file
@@ -29,7 +32,9 @@ async def download_stream_file(output_file,
     """
     async with aiohttp_session.get(file_url) as resp:
         if resp.status != 200:
-            raise RuntimeError(f"Failed to download file at url : {file_url} (status: {resp.status})")
+            raise RuntimeError(
+                f"Failed to download file at url : {file_url} (status: {resp.status})"
+            )
         while True:
             chunk = await resp.content.read(data_chunk_size)
             if not chunk:

--- a/octobot_commons/aiohttp_util.py
+++ b/octobot_commons/aiohttp_util.py
@@ -1,0 +1,41 @@
+#  Drakkar-Software OctoBot-Commons
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+async def download_stream_file(output_file,
+                               file_url,
+                               aiohttp_session,
+                               data_chunk_size=5*2**20,
+                               is_aiofiles_output_file=False):
+    """
+    Download a big file with an aiohttp session
+    :param output_file: the output file
+    :param file_url: the file to be downloaded url
+    :param aiohttp_session: the aiohttp session
+    :param data_chunk_size: default value is 5*2**20 (5MB)
+    :param is_aiofiles_output_file: When True, output_file.write will be awaited (when it's an aiofiles instance)
+    """
+    async with aiohttp_session.get(file_url) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Failed to download file at url : {file_url} (status: {resp.status})")
+        while True:
+            chunk = await resp.content.read(data_chunk_size)
+            if not chunk:
+                # resp.content.read returns an empty chunk when completed
+                break
+            if is_aiofiles_output_file:
+                await output_file.write(chunk)
+            else:
+                output_file.write(chunk)


### PR DESCRIPTION
From Tentacles-Manager/tentacle_fetching.py->_download_tentacles(), will be used for this method and for downloading latest OctoBot binary