### PR TITLE
[PrettyPrinter] Decrease digits for holdings and ref_market_value

### DIFF
--- a/octobot_commons/pretty_printer.pxd
+++ b/octobot_commons/pretty_printer.pxd
@@ -22,8 +22,9 @@ cpdef str global_portfolio_pretty_print(object global_portfolio, dict currency_v
 cpdef str portfolio_profitability_pretty_print(double profitability, object profitability_percent, str reference)
 # cpdef str pretty_print_dict(dict dict_content, default=*, bint markdown=*)
 cpdef double round_with_decimal_count(object number, int max_digits=*)
-cpdef str get_min_string_from_number(object number, int max_digits=*)
+cpdef str get_min_string_from_number(object number, object max_digits=*)
 cpdef tuple get_markers(bint markdown=*)
 
 cdef str _get_row_pretty_portfolio_row(object holdings, str currency, str ref_market, object ref_market_value)
 cdef str _get_markdown_pretty_portfolio_row(object holdings, str currency, str ref_market, object ref_market_value)
+cdef int _get_max_digits(object number)

--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -142,6 +142,19 @@ def _get_row_pretty_portfolio_row(holdings, currency, ref_market, ref_market_val
     return f"{str_holdings} {currency}"
 
 
+def _get_max_digits(number):
+    abs_number = abs(number)
+    if abs_number < 0.0001:
+        return 8
+    if abs_number < 0.01:
+        return 6
+    if abs_number < 1:
+        return 4
+    if abs_number < 100:
+        return 2
+    return 0
+
+
 def _get_markdown_pretty_portfolio_row(
     holdings, currency, ref_market, ref_market_value
 ):
@@ -149,32 +162,12 @@ def _get_markdown_pretty_portfolio_row(
     :return: the portfolio row adapted for a markdown format
     """
     str_currency = "{:<4}".format(currency)
-    if holdings >= 10:
-        str_holdings = "{:<12}".format(
-            get_min_string_from_number(holdings, max_digits=2)
-        )
-    elif holdings >= 1:
-        str_holdings = "{:<12}".format(
-            get_min_string_from_number(holdings, max_digits=4)
-        )
-    else:
-        str_holdings = "{:<12}".format(
-            get_min_string_from_number(holdings, max_digits=6)
-        )
+    str_holdings = "{:<12}".format(get_min_string_from_number(holdings))
     str_ref_market_value = "{:<12}".format("")
     if ref_market:
-        if ref_market_value >= 10:
-            str_ref_market_value = "{:<12}".format(
-                get_min_string_from_number(ref_market_value, max_digits=2)
-            )
-        elif ref_market_value >= 1:
-            str_ref_market_value = "{:<12}".format(
-                get_min_string_from_number(ref_market_value, max_digits=4)
-            )
-        elif ref_market_value < 1:
-            str_ref_market_value = "{:<12}".format(
-                get_min_string_from_number(ref_market_value, max_digits=6)
-            )
+        str_ref_market_value = "{:<12}".format(
+            get_min_string_from_number(ref_market_value)
+        )
     return f"{str_currency} {str_holdings} {str_ref_market_value}"
 
 
@@ -298,13 +291,14 @@ def round_with_decimal_count(number, max_digits=8) -> float:
     return float(get_min_string_from_number(number, max_digits))
 
 
-def get_min_string_from_number(number, max_digits=8) -> str:
+def get_min_string_from_number(number, max_digits=None) -> str:
     """
     Get a min string from number
     :param number: the number
     :param max_digits: the mex digits
     :return: the string from number
     """
+    max_digits = _get_max_digits(number) if max_digits is None else max_digits
     if number is None or round(number, max_digits) == 0.0:
         return "0"
     if number % 1 != 0:

--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -149,16 +149,22 @@ def _get_markdown_pretty_portfolio_row(
     :return: the portfolio row adapted for a markdown format
     """
     str_currency = "{:<4}".format(currency)
-    if holdings > 1: 
+    if holdings >= 10: 
+        str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=2))
+    elif holdings >= 1: 
         str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=4))
     else: 
         str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=6))
     str_ref_market_value = "{:<12}".format("")
     if ref_market:
         str_ref_market_value = "{:<12}".format(
-            get_min_string_from_number(ref_market_value, max_digits=2)
-            if ref_market_value
-            else ""
+            if ref_market_value >= 10:
+                get_min_string_from_number(ref_market_value, max_digits=2)
+            elif ref_market_value >= 1:
+                get_min_string_from_number(ref_market_value, max_digits=4)
+            elif ref_market_value < 1:
+                get_min_string_from_number(ref_market_value, max_digits=6)
+            else: ""
         )
     return f"{str_currency} {str_holdings} {str_ref_market_value}"
 

--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -149,7 +149,10 @@ def _get_markdown_pretty_portfolio_row(
     :return: the portfolio row adapted for a markdown format
     """
     str_currency = "{:<4}".format(currency)
-    str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=4))
+    if holdings > 1: 
+        str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=4))
+    else: 
+        str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=6))
     str_ref_market_value = "{:<12}".format("")
     if ref_market:
         str_ref_market_value = "{:<12}".format(

--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -149,11 +149,11 @@ def _get_markdown_pretty_portfolio_row(
     :return: the portfolio row adapted for a markdown format
     """
     str_currency = "{:<4}".format(currency)
-    str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=6))
+    str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=4))
     str_ref_market_value = "{:<12}".format("")
     if ref_market:
         str_ref_market_value = "{:<12}".format(
-            get_min_string_from_number(ref_market_value) if ref_market_value else ""
+            get_min_string_from_number(ref_market_value, max_digits=2) if ref_market_value else ""
         )
     return f"{str_currency} {str_holdings} {str_ref_market_value}"
 

--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -157,15 +157,13 @@ def _get_markdown_pretty_portfolio_row(
         str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=6))
     str_ref_market_value = "{:<12}".format("")
     if ref_market:
-        str_ref_market_value = "{:<12}".format(
-            if ref_market_value >= 10:
-                get_min_string_from_number(ref_market_value, max_digits=2)
-            elif ref_market_value >= 1:
-                get_min_string_from_number(ref_market_value, max_digits=4)
-            elif ref_market_value < 1:
-                get_min_string_from_number(ref_market_value, max_digits=6)
-            else: ""
-        )
+        if ref_market_value >= 10:
+            str_ref_market_value = "{:<12}".format(get_min_string_from_number(ref_market_value, max_digits=2))
+        elif ref_market_value >= 1:
+            str_ref_market_value = "{:<12}".format(get_min_string_from_number(ref_market_value, max_digits=4))
+        elif ref_market_value < 1:
+            str_ref_market_value = "{:<12}".format(get_min_string_from_number(ref_market_value, max_digits=6))
+        else: ""
     return f"{str_currency} {str_holdings} {str_ref_market_value}"
 
 

--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -149,21 +149,34 @@ def _get_markdown_pretty_portfolio_row(
     :return: the portfolio row adapted for a markdown format
     """
     str_currency = "{:<4}".format(currency)
-    if holdings >= 10: 
-        str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=2))
-    elif holdings >= 1: 
-        str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=4))
-    else: 
-        str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=6))
+    if holdings >= 10:
+        str_holdings = "{:<12}".format(
+            get_min_string_from_number(holdings, max_digits=2)
+        )
+    elif holdings >= 1:
+        str_holdings = "{:<12}".format(
+            get_min_string_from_number(holdings, max_digits=4)
+        )
+    else:
+        str_holdings = "{:<12}".format(
+            get_min_string_from_number(holdings, max_digits=6)
+        )
     str_ref_market_value = "{:<12}".format("")
     if ref_market:
         if ref_market_value >= 10:
-            str_ref_market_value = "{:<12}".format(get_min_string_from_number(ref_market_value, max_digits=2))
+            str_ref_market_value = "{:<12}".format(
+                get_min_string_from_number(ref_market_value, max_digits=2)
+            )
         elif ref_market_value >= 1:
-            str_ref_market_value = "{:<12}".format(get_min_string_from_number(ref_market_value, max_digits=4))
+            str_ref_market_value = "{:<12}".format(
+                get_min_string_from_number(ref_market_value, max_digits=4)
+            )
         elif ref_market_value < 1:
-            str_ref_market_value = "{:<12}".format(get_min_string_from_number(ref_market_value, max_digits=6))
-        else: ""
+            str_ref_market_value = "{:<12}".format(
+                get_min_string_from_number(ref_market_value, max_digits=6)
+            )
+        else:
+            ""
     return f"{str_currency} {str_holdings} {str_ref_market_value}"
 
 

--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -175,8 +175,6 @@ def _get_markdown_pretty_portfolio_row(
             str_ref_market_value = "{:<12}".format(
                 get_min_string_from_number(ref_market_value, max_digits=6)
             )
-        else:
-            """"""
     return f"{str_currency} {str_holdings} {str_ref_market_value}"
 
 

--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -153,7 +153,9 @@ def _get_markdown_pretty_portfolio_row(
     str_ref_market_value = "{:<12}".format("")
     if ref_market:
         str_ref_market_value = "{:<12}".format(
-            get_min_string_from_number(ref_market_value, max_digits=2) if ref_market_value else ""
+            get_min_string_from_number(ref_market_value, max_digits=2)
++            if ref_market_value
++            else ""
         )
     return f"{str_currency} {str_holdings} {str_ref_market_value}"
 

--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -154,8 +154,8 @@ def _get_markdown_pretty_portfolio_row(
     if ref_market:
         str_ref_market_value = "{:<12}".format(
             get_min_string_from_number(ref_market_value, max_digits=2)
-+            if ref_market_value
-+            else ""
+            if ref_market_value
+            else ""
         )
     return f"{str_currency} {str_holdings} {str_ref_market_value}"
 

--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -176,7 +176,7 @@ def _get_markdown_pretty_portfolio_row(
                 get_min_string_from_number(ref_market_value, max_digits=6)
             )
         else:
-            ""
+            """"""
     return f"{str_currency} {str_holdings} {str_ref_market_value}"
 
 

--- a/tests/test_pretty_printer.py
+++ b/tests/test_pretty_printer.py
@@ -38,6 +38,17 @@ def test_get_min_string_from_number():
     assert pretty_printer.get_min_string_from_number(101.04, max_digits=1) == "101"
     assert pretty_printer.get_min_string_from_number(100.00000000, max_digits=8) == "100"
     assert pretty_printer.get_min_string_from_number(-100.00000000, max_digits=8) == "-100"
+    # with computed max_digits
+    assert pretty_printer.get_min_string_from_number(-100.00000001) == "-100"
+    assert pretty_printer.get_min_string_from_number(100.00000001) == "100"
+    assert pretty_printer.get_min_string_from_number(-1.12345678) == "-1.12"
+    assert pretty_printer.get_min_string_from_number(1.12345678) == "1.12"
+    assert pretty_printer.get_min_string_from_number(0.12345678) == "0.1235"
+    assert pretty_printer.get_min_string_from_number(-0.12345678) == "-0.1235"
+    assert pretty_printer.get_min_string_from_number(0.0045678) == "0.004568"
+    assert pretty_printer.get_min_string_from_number(-0.0045678) == "-0.004568"
+    assert pretty_printer.get_min_string_from_number(0.0000456789) == "0.00004568"
+    assert pretty_printer.get_min_string_from_number(-0.0000456789) == "-0.00004568"
 
 
 def test_round_with_decimal_count():


### PR DESCRIPTION
For readability in telegram output decrease the max digits for holdings to 4 and for the reference market value to 2