### PR TITLE
[Profiles] do not raise when validation file is not found

### DIFF
--- a/octobot_commons/profiles/profile.py
+++ b/octobot_commons/profiles/profile.py
@@ -161,7 +161,12 @@ class Profile:
         Validate this profile configuration against self.schema_path
         :return:
         """
-        json_util.validate(self.as_dict(), self.schema_path)
+        try:
+            json_util.validate(self.as_dict(), self.schema_path)
+        except FileNotFoundError as err:
+            commons_logging.get_logger("ProfileSaver").warning(
+                f"Impossible to validate profile: {err} ({err.__class__.__name__})"
+            )
 
     def validate_and_save_config(self) -> None:
         """


### PR DESCRIPTION
fixes this error that can happen when the binary bot is executed for a very long time (tmp folder is erased) :
```
2024-05-30 17:20:49 ERROR  SyncConfigurationStorage logging_util.py:239      [Errno 2] No such file or directory: 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\2\\_MEI57642\\octobot/config/profile_schema.json'
Traceback (most recent call last):
  File "octobot\community\supabase_backend\configuration_storage.py", line 45, in _save_value_in_config
  File "octobot_commons\configuration\configuration.py", line 146, in save
  File "octobot_commons\profiles\profile.py", line 130, in save_config
  File "octobot_commons\profiles\profile.py", line 171, in validate_and_save_config
  File "octobot_commons\profiles\profile.py", line 164, in validate
  File "octobot_commons\json_util.py", line 35, in validate
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\2\\_MEI57642\\octobot/config/profile_schema.json'
2024-05-30 17:20:49 ERROR  SyncConfigurationStorage logging_util.py:210      Error when saving configuration [Errno 2] No such file or directory: 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\2\\_MEI57642\\octobot/config/profile_schema.json' (error: FileNotFoundError)
```